### PR TITLE
Update readme to `custom` ddns type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Ensure you have a Cloudflare account and your domain is configured to point to C
 1. Log in to your [UniFi OS Controller](https://unifi.ui.com/).
 2. Navigate to Settings > Internet > WAN and scroll down to **Dynamic DNS**.
 3. Click **Create New Dynamic DNS** and provide:
-   - `Service`: Choose `dyndns`.
-   - `Hostname`: Full subdomain and hostname to update (e.g., `subdomain.mydomain.com`, `mydomain.com` for root domain).
+   - `Service`: Choose `custom`.
+   - `Hostname`: Full subdomain and hostname to update (e.g., `subdomain.mydomain.com` or `mydomain.com` for root domain).
    - `Username`: Domain name containing the record (e.g., `mydomain.com`).
    - `Password`: Cloudflare API Token.
    - `Server`: Cloudflare Worker route `<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h`.


### PR DESCRIPTION
Closes #62

* Tested using a UDM-Pro running Unifi Network 8.1.113
* Everything in the request sent to the Worker is identical compared to `dyndns`, so it's a drop-in replacement.

Feel free to close if there's a reason dyndns is preferred, but `custom` probably makes more sense here (to me anyway!).