### PR TITLE
Deploy Action: Upgrade actions/checkout to version 4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
Update the Deploy action to use actions/checkout@v4 which uses NodeJS v20 as actions/checkout@v3 uses NodeJS v16 which is deprecated.
Resolves #70 