### PR TITLE
Fix #81 Worker not deploying 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Fix the issue where the worker is not deploying automatically after initial fork when using the Deploy with Workers button
![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)

This is currently not working, and as noted in #81 the workflow must be manually run from the Actions tab (triggers the workflow using the `workflow_dispatch` event). Adding `repository_dispatch` to the Actions workflow enables triggering of the workflow when the Deploy to CloudFlare Workers app calls the "create a repository dispatch event" API endpoint.

Resolves #81 