### PR TITLE
fix: fix regression that removed support for ddclient-based devices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function constructClientOptions(request: Request): ClientOptions {
 function constructDNSRecord(request: Request): AddressableRecord {
 	const url = new URL(request.url);
 	const params = url.searchParams;
-	let ip = params.get('ip');
+	let ip = params.get('ip') || params.get('myip');
 	const hostname = params.get('hostname');
 
 	if (ip === null || ip === undefined) {


### PR DESCRIPTION
reverted to logic used in https://github.com/willswire/unifi-ddns/pull/11

## Changes
Previous pull request added support for older Unifi devices, which use `ddclient` instead of `inadyn`. This fixes a regression that removed support for `ddclient` based devices.
See https://github.com/willswire/unifi-ddns/pull/11

## Checklist
<!--Actions before requesting a review-->
- [ x ] I have performed a self-review of my code
- [ n/a ] If it is a new feature, I have added thorough tests.
