### PR TITLE
Bump the npm_and_yarn group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
 			"devDependencies": {
 				"@cloudflare/vitest-pool-workers": "^0.6.6",
 				"@cloudflare/workers-types": "^4.20250121.0",
-				"@vitest/coverage-istanbul": "^2.1.8",
+				"@vitest/coverage-istanbul": "^2.1.9",
 				"typescript": "^5.7.3",
-				"vitest": "2.1.8",
+				"vitest": "2.1.9",
 				"wrangler": "^3.105.0"
 			}
 		},
@@ -985,9 +985,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
-			"integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
+			"integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
 			"cpu": [
 				"arm"
 			],
@@ -999,9 +999,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
-			"integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
+			"integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1013,9 +1013,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
-			"integrity": "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
+			"integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1027,9 +1027,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
-			"integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
+			"integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
 			"cpu": [
 				"x64"
 			],
@@ -1041,9 +1041,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
-			"integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
+			"integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1055,9 +1055,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
-			"integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
+			"integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1069,9 +1069,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
-			"integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
+			"integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
 			"cpu": [
 				"arm"
 			],
@@ -1083,9 +1083,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
-			"integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
+			"integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
 			"cpu": [
 				"arm"
 			],
@@ -1097,9 +1097,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
-			"integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
+			"integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1111,9 +1111,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
-			"integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
+			"integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1125,9 +1125,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
-			"integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
+			"integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
 			"cpu": [
 				"loong64"
 			],
@@ -1139,9 +1139,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
-			"integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
+			"integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1153,9 +1153,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
-			"integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
+			"integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1167,9 +1167,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
-			"integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
+			"integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1181,9 +1181,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
-			"integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
+			"integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
 			"cpu": [
 				"x64"
 			],
@@ -1195,9 +1195,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
-			"integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
+			"integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
 			"cpu": [
 				"x64"
 			],
@@ -1209,9 +1209,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
-			"integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
+			"integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1223,9 +1223,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
-			"integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
+			"integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1237,9 +1237,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
-			"integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
+			"integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
 			"cpu": [
 				"x64"
 			],
@@ -1277,9 +1277,9 @@
 			}
 		},
 		"node_modules/@vitest/coverage-istanbul": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.8.tgz",
-			"integrity": "sha512-cSaCd8KcWWvgDwEJSXm0NEWZ1YTiJzjicKHy+zOEbUm0gjbbkz+qJf1p8q71uBzSlS7vdnZA8wRLeiwVE3fFTA==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.9.tgz",
+			"integrity": "sha512-vdYE4FkC/y2lxcN3Dcj54Bw+ericmDwiex0B8LV5F/YNYEYP1mgVwhPnHwWGAXu38qizkjOuyczKbFTALfzFKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1298,18 +1298,18 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": "2.1.8"
+				"vitest": "2.1.9"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
-			"integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+			"integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.8",
-				"@vitest/utils": "2.1.8",
+				"@vitest/spy": "2.1.9",
+				"@vitest/utils": "2.1.9",
 				"chai": "^5.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -1318,13 +1318,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
-			"integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+			"integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.8",
+				"@vitest/spy": "2.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.12"
 			},
@@ -1345,9 +1345,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
-			"integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+			"integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1358,13 +1358,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
-			"integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+			"integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "2.1.8",
+				"@vitest/utils": "2.1.9",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -1372,13 +1372,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
-			"integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+			"integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.8",
+				"@vitest/pretty-format": "2.1.9",
 				"magic-string": "^0.30.12",
 				"pathe": "^1.1.2"
 			},
@@ -1387,9 +1387,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
-			"integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+			"integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1400,13 +1400,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
-			"integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+			"integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.8",
+				"@vitest/pretty-format": "2.1.9",
 				"loupe": "^3.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -2249,9 +2249,9 @@
 			}
 		},
 		"node_modules/loupe": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2600,9 +2600,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+			"integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2650,9 +2650,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.31.0.tgz",
-			"integrity": "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==",
+			"version": "4.34.6",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
+			"integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2666,25 +2666,25 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.31.0",
-				"@rollup/rollup-android-arm64": "4.31.0",
-				"@rollup/rollup-darwin-arm64": "4.31.0",
-				"@rollup/rollup-darwin-x64": "4.31.0",
-				"@rollup/rollup-freebsd-arm64": "4.31.0",
-				"@rollup/rollup-freebsd-x64": "4.31.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.31.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.31.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.31.0",
-				"@rollup/rollup-linux-arm64-musl": "4.31.0",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.31.0",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.31.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.31.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.31.0",
-				"@rollup/rollup-linux-x64-gnu": "4.31.0",
-				"@rollup/rollup-linux-x64-musl": "4.31.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.31.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.31.0",
-				"@rollup/rollup-win32-x64-msvc": "4.31.0",
+				"@rollup/rollup-android-arm-eabi": "4.34.6",
+				"@rollup/rollup-android-arm64": "4.34.6",
+				"@rollup/rollup-darwin-arm64": "4.34.6",
+				"@rollup/rollup-darwin-x64": "4.34.6",
+				"@rollup/rollup-freebsd-arm64": "4.34.6",
+				"@rollup/rollup-freebsd-x64": "4.34.6",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
+				"@rollup/rollup-linux-arm-musleabihf": "4.34.6",
+				"@rollup/rollup-linux-arm64-gnu": "4.34.6",
+				"@rollup/rollup-linux-arm64-musl": "4.34.6",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
+				"@rollup/rollup-linux-riscv64-gnu": "4.34.6",
+				"@rollup/rollup-linux-s390x-gnu": "4.34.6",
+				"@rollup/rollup-linux-x64-gnu": "4.34.6",
+				"@rollup/rollup-linux-x64-musl": "4.34.6",
+				"@rollup/rollup-win32-arm64-msvc": "4.34.6",
+				"@rollup/rollup-win32-ia32-msvc": "4.34.6",
+				"@rollup/rollup-win32-x64-msvc": "4.34.6",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -3200,9 +3200,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
-			"integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+			"integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3636,19 +3636,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
-			"integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+			"integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "2.1.8",
-				"@vitest/mocker": "2.1.8",
-				"@vitest/pretty-format": "^2.1.8",
-				"@vitest/runner": "2.1.8",
-				"@vitest/snapshot": "2.1.8",
-				"@vitest/spy": "2.1.8",
-				"@vitest/utils": "2.1.8",
+				"@vitest/expect": "2.1.9",
+				"@vitest/mocker": "2.1.9",
+				"@vitest/pretty-format": "^2.1.9",
+				"@vitest/runner": "2.1.9",
+				"@vitest/snapshot": "2.1.9",
+				"@vitest/spy": "2.1.9",
+				"@vitest/utils": "2.1.9",
 				"chai": "^5.1.2",
 				"debug": "^4.3.7",
 				"expect-type": "^1.1.0",
@@ -3660,7 +3660,7 @@
 				"tinypool": "^1.0.1",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.1.8",
+				"vite-node": "2.1.9",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -3675,8 +3675,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "2.1.8",
-				"@vitest/ui": "2.1.8",
+				"@vitest/browser": "2.1.9",
+				"@vitest/ui": "2.1.9",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.6.6",
 		"@cloudflare/workers-types": "^4.20250121.0",
-		"@vitest/coverage-istanbul": "^2.1.8",
+		"@vitest/coverage-istanbul": "^2.1.9",
 		"typescript": "^5.7.3",
-		"vitest": "2.1.8",
+		"vitest": "2.1.9",
 		"wrangler": "^3.105.0"
 	},
 	"dependencies": {


### PR DESCRIPTION
Bumps the npm_and_yarn group with 2 updates: [vitest](https://github.com/vitest-dev/vitest/tree/HEAD/packages/vitest) and [@vitest/coverage-istanbul](https://github.com/vitest-dev/vitest/tree/HEAD/packages/coverage-istanbul).


Updates `vitest` from 2.1.8 to 2.1.9
- [Release notes](https://github.com/vitest-dev/vitest/releases)
- [Commits](https://github.com/vitest-dev/vitest/commits/v2.1.9/packages/vitest)

Updates `@vitest/coverage-istanbul` from 2.1.8 to 2.1.9
- [Release notes](https://github.com/vitest-dev/vitest/releases)
- [Commits](https://github.com/vitest-dev/vitest/commits/v2.1.9/packages/coverage-istanbul)

---
updated-dependencies:
- dependency-name: vitest dependency-type: direct:development dependency-group: npm_and_yarn
- dependency-name: "@vitest/coverage-istanbul" dependency-type: direct:development dependency-group: npm_and_yarn ...

## Changes
<!--Describe your changes here; whether they be to address a bug or add new features-->

## Checklist
<!--Actions before requesting a review-->
- [ ] I have performed a self-review of my code
- [ ] If it is a new feature, I have added thorough tests.
