### PR TITLE
fix: trim whitespace from query parameters to prevent cryptic errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,9 @@ function constructClientOptions(request: Request): ClientOptions {
 function constructDNSRecords(request: Request): AddressableRecord[] {
 	const url = new URL(request.url);
 	const params = url.searchParams;
-	let ip = params.get('ip') || params.get('myip');
-	const ip6 = params.get('ip6');
-	const hostname = params.get('hostname');
+	let ip = (params.get('ip') || params.get('myip'))?.trim() || null;
+	const ip6 = params.get('ip6')?.trim() || null;
+	const hostname = params.get('hostname')?.trim() || null;
 
 	if (ip === null || ip === undefined) {
 		throw new HttpError(422, 'The "ip" parameter is required and cannot be empty. Specify ip=auto to use the client IP.');


### PR DESCRIPTION
Leading/trailing spaces in the workers.dev URL (common when copy-pasting from Cloudflare) caused UniFi to show unhelpful error messages. Trimming input parameters handles this gracefully.

## Changes
<!--Describe your changes here; whether they be to address a bug or add new features-->
Closes #196

## Checklist
<!--Actions before requesting a review-->
- [ ] I have performed a self-review of my code
- [ ] If it is a new feature, I have added thorough tests.
