### PR TITLE
fix: add missing ttl to dns.records.update call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ async function update(clientOptions: ClientOptions, newRecords: AddressableRecor
 			zone_id: zone.id,
 			name: newRecord.name as any,
 			type: newRecord.type,
+			ttl: newRecord.ttl,
 			proxied, // Pass the existing "proxied" status
 			comment, // Pass the existing "comment"
 		});


### PR DESCRIPTION
## Summary

- Adds missing `ttl` property to the `cloudflare.dns.records.update()` call, fixing a TypeScript type error where `RecordUpdateParams` requires `ttl` but it wasn't being passed through

## Test plan

- [x] All 18 tests pass
- [x] `tsc --noEmit` shows no project-level errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)