### PR TITLE
fix(ci): use project wrangler instead of outdated wrangler-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,15 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v6
-      - name: Deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          node-version: lts/*
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Deploy
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Replaces the pinned `cloudflare/wrangler-action` (which installed wrangler 3.90.0) with `npm ci` + `npx wrangler deploy`
- Ensures the project's own wrangler 4.70.0 and the `cloudflare` SDK are both installed before deploy
- Adds `setup-node` with caching for faster CI runs

The old action was causing deploys to fail with `502 Bad Gateway` because it used an outdated wrangler version that didn't properly bundle the cloudflare SDK dependency.

## Test plan

- [ ] Merge and verify the deploy workflow succeeds on main
- [ ] Confirm the worker is accessible at `*.workers.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)