### PR TITLE
feat: add optional proxied query param to pin Cloudflare proxy state

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ UniFi devices running older firmware do not natively support Cloudflare as a DDN
    - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h`
      *(Omit `https://`)*
 
+#### Optional: pin Cloudflare proxy (orange cloud) state on every update
+
+By default, the worker preserves the current **Proxy status** of the record. If you rely on Cloudflare's orange cloud (for example to terminate SSL so a browser can reach a plain HTTP service behind your UniFi gateway), append `&proxied=true` to the server URL:
+
+```
+<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h&proxied=true
+```
+
+With `proxied=true`, the worker always writes the record with the Cloudflare proxy enabled even if something upstream (or a manual change in the dashboard) flipped it off. Conversely, `proxied=false` pins the record as DNS only on every update. Accepted values are case insensitive (`true` or `1` enable, `false` or `0` disable). Omitting the parameter, or passing any other value, leaves the existing proxy state untouched, so existing users are unaffected.
+
 ## 🛠️ **Testing & Troubleshooting**
 
 Using this script with various Ubiquiti devices and different UniFi software versions can introduce unique challenges. If you encounter issues, start by checking the FAQ in `/docs/faq.md`. If you don’t find a solution, you can ask a question on the [discussions page](https://github.com/willswire/unifi-ddns/discussions/new?category=q-a). If the problem persists, please raise an issue [here](https://github.com/willswire/unifi-ddns/issues).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -143,7 +143,19 @@ Common error messages and their meanings:
 - **"No zones found"** or **"More than one zone"** — Your API token is not scoped to exactly one zone. Create a new token with the correct scope.
 - **"No record found"** — The DNS record must already exist in Cloudflare before the worker can update it. Manually create an A or AAAA record first.
 
-## 14. What should I do if I continue to experience issues with DDNS updates?
+## 14. How do I pin the Cloudflare proxy (orange cloud) state on every DDNS update?
+
+By default, the worker preserves whatever **Proxy status** the record currently has, so if you leave the orange cloud on in the dashboard it stays on. Some setups (for example the native UniFi Cloudflare DDNS client) can flip the record back to DNS only, which breaks anything that relies on Cloudflare terminating TLS for a plain HTTP origin.
+
+To pin the proxy on from the worker side, append `proxied=true` to the server URL:
+
+```
+<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h&proxied=true
+```
+
+With `proxied=true` the worker always writes the record with the Cloudflare proxy enabled. Conversely, `proxied=false` pins the record as DNS only on every update. Accepted values are case insensitive (`true` or `1` enable, `false` or `0` disable). Omitting the parameter, or passing any other value, leaves the existing proxy state untouched, so existing setups are unaffected.
+
+## 15. What should I do if I continue to experience issues with DDNS updates?
 
 - **Verify Configuration:**
   - Double-check all entries in your DDNS settings for accuracy.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,17 @@ function constructClientOptions(request: Request): ClientOptions {
 	};
 }
 
+function parseProxiedOverride(request: Request): boolean | null {
+	const raw = new URL(request.url).searchParams.get('proxied');
+	if (raw === null) {
+		return null;
+	}
+	const normalized = raw.trim().toLowerCase();
+	if (normalized === 'true' || normalized === '1') return true;
+	if (normalized === 'false' || normalized === '0') return false;
+	return null;
+}
+
 function constructDNSRecords(request: Request): AddressableRecord[] {
 	const url = new URL(request.url);
 	const params = url.searchParams;
@@ -83,7 +94,11 @@ function constructDNSRecords(request: Request): AddressableRecord[] {
 	return records;
 }
 
-async function update(clientOptions: ClientOptions, newRecords: AddressableRecord[]): Promise<Response> {
+async function update(
+	clientOptions: ClientOptions,
+	newRecords: AddressableRecord[],
+	proxiedOverride: boolean | null,
+): Promise<Response> {
 	const cloudflare = new Cloudflare(clientOptions);
 
 	const tokenStatus = (await cloudflare.user.tokens.verify()).status;
@@ -117,7 +132,11 @@ async function update(clientOptions: ClientOptions, newRecords: AddressableRecor
 
 		// Extract current properties
 		const currentRecord = records[0] as AddressableRecord;
-		const proxied = currentRecord.proxied ?? false; // Default to `false` if `proxied` is undefined
+		// Preserve the current `proxied` state unless the request explicitly overrides it.
+		// The native UniFi DDNS client does not preserve proxy status on update, so callers
+		// can pin it with `?proxied=true` (or force off with `?proxied=false`) in the
+		// configured DDNS server URL.
+		const proxied = proxiedOverride ?? currentRecord.proxied ?? false;
 		const comment = currentRecord.comment;
 
 		await cloudflare.dns.records.update(records[0].id, {
@@ -126,7 +145,7 @@ async function update(clientOptions: ClientOptions, newRecords: AddressableRecor
 			name: newRecord.name as any,
 			type: newRecord.type,
 			ttl: newRecord.ttl,
-			proxied, // Pass the existing "proxied" status
+			proxied, // Overridden value if `proxied` query param was set, otherwise the existing status
 			comment, // Pass the existing "comment"
 		});
 
@@ -146,9 +165,10 @@ export default {
 			// Construct client options and DNS records
 			const clientOptions = constructClientOptions(request);
 			const records = constructDNSRecords(request);
+			const proxiedOverride = parseProxiedOverride(request);
 
 			// Run the update function
-			return await update(clientOptions, records);
+			return await update(clientOptions, records, proxiedOverride);
 		} catch (error) {
 			if (error instanceof HttpError) {
 				console.log('Error updating DNS record: ' + error.message);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -290,4 +290,172 @@ describe('UniFi DDNS Worker', () => {
 		expect(response.status).toBe(422);
 		expect(await response.text()).toBe('The "ip6" parameter must be a valid IPv6 address.');
 	});
+
+	// The suite level beforeEach calls vi.clearAllMocks(), which clears call history but
+	// not mock implementations (including mockResolvedValue defaults and leftover
+	// mockResolvedValueOnce queues set by earlier tests). The specs below exercise the
+	// proxied query param behaviour and must start from a fully clean mock slate, so they
+	// call resetCfMocks() explicitly to avoid disturbing the mock setup patterns the
+	// existing tests rely on.
+	function resetCfMocks() {
+		mockVerify.mockReset();
+		mockListZones.mockReset();
+		mockListRecords.mockReset();
+		mockUpdateRecord.mockReset();
+	}
+
+	it('preserves existing proxied status when proxied query param is absent', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: true }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com', {
+			headers: {
+				Authorization: 'Basic ' + btoa('email@example.com:validtoken'),
+			},
+		}));
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: true }),
+		);
+	});
+
+	it('forces proxied=true when proxied=true is passed, overriding an existing unproxied record', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: false }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com&proxied=true', {
+				headers: {
+					Authorization: 'Basic ' + btoa('email@example.com:validtoken'),
+				},
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: true }),
+		);
+	});
+
+	it('accepts proxied=1 as an alias for proxied=true', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: false }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com&proxied=1', {
+				headers: { Authorization: 'Basic ' + btoa('email@example.com:validtoken') },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: true }),
+		);
+	});
+
+	it('applies proxied=true override to every record in a comma-separated multi-hostname update', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords
+			.mockResolvedValueOnce({ result: [{ id: 'record-id-1', name: 'example.com', type: 'A', proxied: false }] })
+			.mockResolvedValueOnce({ result: [{ id: 'record-id-2', name: '*.example.com', type: 'A', proxied: false }] });
+		mockUpdateRecord.mockResolvedValue({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=example.com,*.example.com&proxied=true', {
+				headers: { Authorization: 'Basic ' + btoa('email@example.com:validtoken') },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledTimes(2);
+		expect(mockUpdateRecord).toHaveBeenNthCalledWith(1, 'record-id-1', expect.objectContaining({ proxied: true }));
+		expect(mockUpdateRecord).toHaveBeenNthCalledWith(2, 'record-id-2', expect.objectContaining({ proxied: true }));
+	});
+
+	it('forces proxied=false when proxied=false is passed, overriding an existing proxied record', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: true }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com&proxied=false', {
+				headers: { Authorization: 'Basic ' + btoa('email@example.com:validtoken') },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: false }),
+		);
+	});
+
+	it('accepts proxied=0 as an alias for proxied=false', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: true }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com&proxied=0', {
+				headers: { Authorization: 'Basic ' + btoa('email@example.com:validtoken') },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: false }),
+		);
+	});
+
+	it('ignores unrecognized proxied values and preserves existing state', async () => {
+		resetCfMocks();
+		mockVerify.mockResolvedValueOnce({ status: 'active' });
+		mockListZones.mockResolvedValueOnce({ result: [{ id: 'zone-id' }] });
+		mockListRecords.mockResolvedValueOnce({
+			result: [{ id: 'record-id', name: 'home.example.com', type: 'A', proxied: true }],
+		});
+		mockUpdateRecord.mockResolvedValueOnce({});
+
+		const response = await worker.fetch(
+			new Request('http://example.com/update?ip=192.0.2.1&hostname=home.example.com&proxied=garbage', {
+				headers: { Authorization: 'Basic ' + btoa('email@example.com:validtoken') },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockUpdateRecord).toHaveBeenCalledWith(
+			'record-id',
+			expect.objectContaining({ proxied: true }),
+		);
+	});
 });


### PR DESCRIPTION
## Summary

Adds an optional `proxied` query string parameter to `/update` that lets the caller pin the Cloudflare proxy (orange cloud) state on every DDNS update.

`?proxied=true` or `?proxied=1` forces the record proxied.
`?proxied=false` or `?proxied=0` forces DNS only.
Omitting the parameter, or passing any other value, preserves the current state (today's behaviour).

Values are trimmed and case insensitive. The override applies to every record in an update that passes multiple hostnames (comma separated).

Related: #226 (Discussion with the use case).

## Motivation

The worker preserves whatever `proxied` flag each record already has. The native UniFi Cloudflare DDNS client running alongside or before this worker can flip records back to DNS only between runs. Anything relying on Cloudflare TLS via the orange cloud then stops working until someone flips it back in the dashboard.

The worker already runs on every DDNS update and holds the record context, so it looks like the right place to pin the state from.

## Backwards compatibility

Fully opt in. Existing DDNS URLs without the parameter behave exactly as before: the current `proxied` value is read from Cloudflare and written back unchanged. Any value other than `true`, `1`, `false`, `0` is treated as "preserve", so a typo cannot silently flip state.

## Changes

`src/index.ts` adds a `parseProxiedOverride(request)` helper that returns `boolean | null`. `update()` takes a third `proxiedOverride` argument and uses `proxiedOverride ?? currentRecord.proxied ?? false` when writing. Around 15 lines of real logic.

`test/index.spec.ts` adds 7 vitest specs covering the omitted parameter, `proxied=true` override, `proxied=1` alias, override on an update with multiple hostnames, `proxied=false` override, `proxied=0` alias, and an unrecognised value that preserves state. A `resetCfMocks()` helper was factored out of the repeated mock setup.

`README.md` and `docs/faq.md` document the new parameter and the accepted values.

## Test plan

`npx vitest run` passes 25 of 25 tests locally, including the 7 added specs. CI runs `coverage.yml` on the PR. Happy to verify on a live Cloudflare Worker if you'd like.

## Notes

Both directions (`true` and `false`) are accepted on purpose, so users whose upstream flipped the record into proxied when they actually want DNS only have a way back too. No new dependencies. The commit uses the `feat:` prefix so the release workflow picks up a minor version bump on merge.