### PR TITLE
Use existing TTL instead of overwriting to 1 (auto)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ async function update(clientOptions: ClientOptions, newRecords: AddressableRecor
 			zone_id: zone.id,
 			name: newRecord.name as any,
 			type: newRecord.type,
-			ttl: newRecord.ttl,
+			ttl: currentRecord.ttl,
 			proxied, // Pass the existing "proxied" status
 			comment, // Pass the existing "comment"
 		});


### PR DESCRIPTION
## Changes
When the DNS records gets updated, TTL gets overwritten to 1 (Auto) instead of keeping the existing setting. 
This changes preserves the existing TTL.

## Checklist
<!--Actions before requesting a review-->
- [x] I have performed a self-review of my code
- [x] If it is a new feature, I have added thorough tests.

I have tested this on my deployed wrangler worker and the TTL is now preserved.